### PR TITLE
Actualiza ARSoftware.Contpaqi.Api.Common de 1.0.0 a 1.0.1

### DIFF
--- a/src/Api.Core.Domain/Api.Core.Domain.csproj
+++ b/src/Api.Core.Domain/Api.Core.Domain.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ARSoftware.Contpaqi.Api.Common" Version="1.0.0" />
+		<PackageReference Include="ARSoftware.Contpaqi.Api.Common" Version="1.0.1" />
 		<PackageReference Include="ARSoftware.Contpaqi.Comercial.Sdk.Extras" Version="4.4.0" />
 		<PackageReference Include="MediatR" Version="12.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Este PR actualiza ARSoftware.Contpaqi.Api.Common de 1.0.0 a 1.0.1.

Esta version corrige un error que se presentaba en la API al querer deserializar un ErrorContpaqiResponse.

## Closes
* #9 