### PR TITLE
Corregir base address

### DIFF
--- a/src/Api.Sync.Infrastructure/ContpaqiComercialApi/ContpaqiComercialApiService.cs
+++ b/src/Api.Sync.Infrastructure/ContpaqiComercialApi/ContpaqiComercialApiService.cs
@@ -22,7 +22,7 @@ public sealed class ContpaqiComercialApiService : IContpaqiComercialApiService
 
     public async Task<IEnumerable<ApiRequest>> GetPendingRequestsAsync(CancellationToken cancellationToken)
     {
-        HttpResponseMessage message = await _httpClient.GetAsync("/api/Requests/Pending", cancellationToken);
+        HttpResponseMessage message = await _httpClient.GetAsync("api/Requests/Pending", cancellationToken);
 
         message.EnsureSuccessStatusCode();
 
@@ -47,7 +47,7 @@ public sealed class ContpaqiComercialApiService : IContpaqiComercialApiService
         var data = new StringContent(json, Encoding.UTF8, "application/json");
 
         HttpResponseMessage httpResponseMessage =
-            await _httpClient.PostAsync($"/api/requests/{apiRequestId}/response", data, cancellationToken);
+            await _httpClient.PostAsync($"api/Requests/{apiRequestId}/Response", data, cancellationToken);
 
         httpResponseMessage.EnsureSuccessStatusCode();
     }

--- a/src/Api.Sync.Presentation.WorkerService/appsettings.json
+++ b/src/Api.Sync.Presentation.WorkerService/appsettings.json
@@ -27,7 +27,7 @@
   },
   "ApiSyncConfig": {
     "SubscriptionKey": "00000000000000000000000000000000",
-    "BaseAddress": "https://contpaqiapim.azure-api.net/comercial",
+    "BaseAddress": "https://contpaqiapim.azure-api.net/comercial/",
     "WaitTime": "00:00:30",
     "ShutdownTime": "20:00:00",
     "Empresas": [ "URE180429TM6" ]


### PR DESCRIPTION
Este PR corrige las URLs utilizadas para comunicarse con la API. 

Este cambio fue necesario ya que a diferencia del ambiente de pruebas donde la dirección es `https://localhost:7082`, en el ambiente de producción es `https://contpaqiapim.azure-api.net/comercial/`. Como antes estaba configurado, se borraba `/comercial` de la URL y el sincronizador tronaba.

## Closes
- #11