### PR TITLE
feat: inicia sesion de CONTPAQi Contabilidad

### DIFF
--- a/src/Api.Sync.Core.Application/Common/Models/ContpaqiComercialConfig.cs
+++ b/src/Api.Sync.Core.Application/Common/Models/ContpaqiComercialConfig.cs
@@ -4,6 +4,7 @@ public sealed class ContpaqiComercialConfig
 {
     public string Usuario { get; set; } = string.Empty;
     public string Contrasena { get; set; } = string.Empty;
+    public bool HayIntefazConEmpresaContabilidad { get; set; }
     public string RutaPlantillasPdf { get; set; } = string.Empty;
     public Empresa Empresa { get; set; } = new();
 }

--- a/src/Api.Sync.Core.Application/ContpaqiComercial/Commands/IniciarSdk/IniciarSdkCommand.cs
+++ b/src/Api.Sync.Core.Application/ContpaqiComercial/Commands/IniciarSdk/IniciarSdkCommand.cs
@@ -25,9 +25,14 @@ public sealed class IniciarSdkCommandHandler : IRequestHandler<IniciarSdkCommand
     public Task Handle(IniciarSdkCommand request, CancellationToken cancellationToken)
     {
         if (!_sdkSesionService.IsSdkInicializado)
-            _sdkSesionService.IniciarSesionSdk(_contpaqiComercialConfig.Usuario, _contpaqiComercialConfig.Contrasena);
+        {
+            if (_contpaqiComercialConfig.HayIntefazConEmpresaContabilidad)
+                _sdkSesionService.IniciarSesionSdk(_contpaqiComercialConfig.Usuario, _contpaqiComercialConfig.Contrasena,
+                    _contpaqiComercialConfig.Usuario, _contpaqiComercialConfig.Contrasena);
+            else
+                _sdkSesionService.IniciarSesionSdk(_contpaqiComercialConfig.Usuario, _contpaqiComercialConfig.Contrasena);
+        }
 
-        // Todo: Contabilidad?
         _logger.LogDebug("SDK inicializado. {@ComercialSdkSesionService}", _sdkSesionService);
 
         return Task.CompletedTask;

--- a/src/Api.Sync.Presentation.WorkerService/appsettings.json
+++ b/src/Api.Sync.Presentation.WorkerService/appsettings.json
@@ -35,6 +35,7 @@
   "ContpaqiComercialConfig": {
     "Usuario": "SUPERVISOR",
     "Contrasena": "",
+    "HayIntefazConEmpresaContabilidad": false,
     "RutaPlantillasPdf": "C:\\Compac\\Empresas\\Reportes\\Formatos Digitales\\reportes_Servidor\\COMERCIAL"
   }
 }


### PR DESCRIPTION
Hay empresas de CONTPAQi Comercial que tienen interfaz con una empresa de CONTPAQi Contabilidad. Cuando se trabaja con este tipo de empresas al momento de que el sincronizador intenta abrir la empresa se abre una ventana que solicita las credenciales de CONTPAQi Contabilidad. Las credenciales se deben ingresar manualmente para continuar por lo que no es óptimo para este tipo de desarrollo.

Este PR agrega una propiedad en la configuración de Comercial para saber si existe una interfaz con el sistema contable. Cuando esta se marca con el valor `true`, al momento de iniciar sesión de Comercial también se inicia sesión de Contabilidad.

Las credenciales a utilizar son las mimas ya configuradas para el sistema de Comercial, por lo que debe existir un usuario en Contabilidad con el mismo nombre de usuario y contraseña que utiliza el sincronizar para iniciar sesión en Comercial.