### PR TITLE
feat: espera hasta 25 segundos a que el sincronizador procese la solicitud

### DIFF
--- a/src/Api.Sync.Presentation.WorkerService/appsettings.Development.json
+++ b/src/Api.Sync.Presentation.WorkerService/appsettings.Development.json
@@ -21,7 +21,7 @@
     ]
   },
   "ConnectionStrings": {
-    "Contpaqi": "Data Source=AR-SERVER\\COMPAC;User ID=sa;Password=Sdmramos1;Connect Timeout=30;"
+    "Contpaqi": "Data Source=AR-SERVER\\COMPAC;User ID=sa;Password=Sdmramos1;Connect Timeout=30;Encrypt=False;"
   },
   "ApiSyncConfig": {
     "BaseAddress": "https://localhost:7082/",

--- a/src/Api.Sync.Presentation.WorkerService/appsettings.json
+++ b/src/Api.Sync.Presentation.WorkerService/appsettings.json
@@ -23,7 +23,7 @@
     ]
   },
   "ConnectionStrings": {
-    "Contpaqi": "Data Source=AR-SERVER\\COMPAC;User ID=sa;Password=Sdmramos1;Connect Timeout=30;"
+    "Contpaqi": "Data Source=AR-SERVER\\COMPAC;User ID=sa;Password=Sdmramos1;Connect Timeout=30;Encrypt=False;"
   },
   "ApiSyncConfig": {
     "SubscriptionKey": "00000000000000000000000000000000",


### PR DESCRIPTION
En este PR se agrega el header `x-Empresa-Rfc` de tipo `bool` que cuando el valor sea `true` la API esperara hasta 25 segundos para que el sincronizador procese el `ContpaqiRequest `. Si dentro de este periodo de tiempo el sincronizador procesa la solicitud, la respuesta también tendrá asignado su `ContpaqiResponse`.

Este header es opcional.

El propósito de este cambio es evitar tener que hacer una segunda petición a la API para validar el estatus y respuesta de la solicitud.