### PR TITLE
feat: carga contenido de archivos digitales

### DIFF
--- a/docs/Requests/Documentos/CrearFacturaResponse.json
+++ b/docs/Requests/Documentos/CrearFacturaResponse.json
@@ -11,7 +11,7 @@
       },
       "serie": "",
       "folio": 0,
-      "fecha": "2023-08-04T00:00:00-05:00",
+      "fecha": "2023-08-05T00:00:00-05:00",
       "cliente": {
         "id": 0,
         "codigo": "CLIENTEPRUEBA",
@@ -131,16 +131,16 @@
       }
     },
     "xml": {
-      "nombre": "",
-      "tipo": "",
-      "ubicacion": "",
-      "contenido": null
+      "nombre": "FACTURA100.xml",
+      "tipo": "text/xml",
+      "ubicacion": "C:\\Compac\\Empresas\\adUNIVERSIDAD_ROBOTICA\\XML_SDK\\FACTURA100.xml",
+      "contenido": "HuXrFGV/AfJp4N5GQKtgnW/xG+EfCvoY2dyPBhYOYkBCMiQ1DHX9vwflU/wxdsTcMo0Ca8VSXZOBEX1nPcn9vLaahzjSNg=="
     },
     "pdf": {
-      "nombre": "",
-      "tipo": "",
-      "ubicacion": "",
-      "contenido": null
+      "nombre": "FACTURA100.pdf",
+      "tipo": "application/pdf",
+      "ubicacion": "C:\\Compac\\Empresas\\adUNIVERSIDAD_ROBOTICA\\XML_SDK\\FACTURA100.pdf",
+      "contenido": "D0GUpoBKmvO0FW8cgre4WCngeE2hPNEQgxUbEOM7Pco0k+Mnl6hJ3FfTvKogD8/q3Eh1UL3uo8GnGFPw2HNQpdSRmuosaw=="
     }
   }
 }

--- a/docs/Requests/Documentos/GenerarDocumentoDigitalResponse.json
+++ b/docs/Requests/Documentos/GenerarDocumentoDigitalResponse.json
@@ -2,10 +2,10 @@
   "$type": "GenerarDocumentoDigitalResponse",
   "model": {
     "documentoDigital": {
-      "nombre": "",
-      "tipo": "",
-      "ubicacion": "",
-      "contenido": null
+      "nombre": "FACTURA100.pdf",
+      "tipo": "application/pdf",
+      "ubicacion": "C:\\Compac\\Empresas\\adUNIVERSIDAD_ROBOTICA\\XML_SDK\\FACTURA100.pdf",
+      "contenido": "A+ZNw3o3ZQkvHQGH686cc9HmazumuuixPiRbs6p2bNcmXXX0ATCvig977aL4ZWX7JWUEdkZm8DgePGn3utzAQ/oolo8bsQ=="
     }
   }
 }

--- a/samples/Api.Sdk.ConsoleApp/JsonFactories/DocumentoFactory.cs
+++ b/samples/Api.Sdk.ConsoleApp/JsonFactories/DocumentoFactory.cs
@@ -45,7 +45,21 @@ public static class DocumentoFactory
 
     private static CrearFacturaResponse GetCrearFacturaResponse()
     {
-        return new CrearFacturaResponse(new CrearFacturaResponseModel(GetModeloPrueba(), new DocumentoDigital(), new DocumentoDigital()));
+        return new CrearFacturaResponse(new CrearFacturaResponseModel(GetModeloPrueba(),
+            new DocumentoDigital
+            {
+                Nombre = "FACTURA100.xml",
+                Tipo = "text/xml",
+                Ubicacion = "C:\\Compac\\Empresas\\adUNIVERSIDAD_ROBOTICA\\XML_SDK\\FACTURA100.xml",
+                Contenido = GetBytesPrueba()
+            },
+            new DocumentoDigital
+            {
+                Nombre = "FACTURA100.pdf",
+                Tipo = "application/pdf",
+                Ubicacion = "C:\\Compac\\Empresas\\adUNIVERSIDAD_ROBOTICA\\XML_SDK\\FACTURA100.pdf",
+                Contenido = GetBytesPrueba()
+            }));
     }
 
     private static ActualizarDocumentoRequest GetActualizarDocumentoRequest()
@@ -91,7 +105,13 @@ public static class DocumentoFactory
 
     private static GenerarDocumentoDigitalResponse GetGenerarDocumentoDigitalResponse()
     {
-        return new GenerarDocumentoDigitalResponse(new GenerarDocumentoDigitalResponseModel(new DocumentoDigital()));
+        return new GenerarDocumentoDigitalResponse(new GenerarDocumentoDigitalResponseModel(new DocumentoDigital
+        {
+            Nombre = "FACTURA100.pdf",
+            Tipo = "application/pdf",
+            Ubicacion = "C:\\Compac\\Empresas\\adUNIVERSIDAD_ROBOTICA\\XML_SDK\\FACTURA100.pdf",
+            Contenido = GetBytesPrueba()
+        }));
     }
 
     private static SaldarDocumentoRequest GetSaldarDocumentoRequest()
@@ -186,6 +206,13 @@ public static class DocumentoFactory
             { nameof(admDocumentos.CTEXTOEXTRA2), "Texto extra 2" },
             { nameof(admDocumentos.CTEXTOEXTRA3), "Texto extra 3" }
         };
+    }
+
+    private static byte[] GetBytesPrueba()
+    {
+        var b = new byte[70];
+        new Random().NextBytes(b);
+        return b;
     }
 
     public static void CearJson(string directory)

--- a/src/Api.Core.Domain/Models/DocumentoDigital.cs
+++ b/src/Api.Core.Domain/Models/DocumentoDigital.cs
@@ -13,12 +13,12 @@ public sealed class DocumentoDigital
     public string Tipo { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Ubicacion del documento.
+    ///     Ubicación del documento.
     /// </summary>
     public string Ubicacion { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Contenido del documento. Solo aplica para los XML.
+    ///     Contenido del documento. Cuando se serializa a JSON, se convierte a Base64.
     /// </summary>
-    public string? Contenido { get; set; }
+    public byte[]? Contenido { get; set; }
 }

--- a/src/Api.Sync.Core.Application/Requests/Documentos/GenerarDocumentoDigital/GenerarDocumentoDigitalRequestHandler.cs
+++ b/src/Api.Sync.Core.Application/Requests/Documentos/GenerarDocumentoDigital/GenerarDocumentoDigitalRequestHandler.cs
@@ -39,9 +39,7 @@ public sealed class GenerarDocumentoDigitalRequestHandler : IRequestHandler<Gene
             Ubicacion = rutaDocumento,
             Nombre = new FileInfo(rutaDocumento).Name,
             Tipo = request.Options.Tipo == TipoArchivoDigital.Pdf ? "application/pdf" : "text/xml",
-            Contenido = request.Options.Tipo == TipoArchivoDigital.Xml
-                ? await File.ReadAllTextAsync(rutaDocumento, cancellationToken)
-                : null
+            Contenido = await File.ReadAllBytesAsync(rutaDocumento, cancellationToken)
         };
 
         return GenerarDocumentoDigitalResponse.CreateInstance(documentoDigital);


### PR DESCRIPTION
En este PR se agregó la columna `Contenido` de tipo `byte[]` al modelo `DocumentoDigital`.

A esta columna se asigna el contenido de los documentos digitales, por ejemplos los PDF y XML. De esta forma podrás descargar los archivos a tu aplicación.

Cuando esta propiedad se serializa a JSON este se convierte en un `string` base64.

Lo recomendable es convertir y guardar los documentos en un contenedor de archivos propios.