### PR TITLE
feat: notifica al sincronizador en tiempo real cuando hay requests pendientes por procesar

### DIFF
--- a/src/Api.Core.Domain/Common/GetPendingRequestsMessage.cs
+++ b/src/Api.Core.Domain/Common/GetPendingRequestsMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace Api.Core.Domain.Common;
+
+public sealed record GetPendingRequestsMessage(string SubscriptionKey, string EmpresaRfc);

--- a/src/Api.Presentation.WebApi/Hubs/ApiRequestHub.cs
+++ b/src/Api.Presentation.WebApi/Hubs/ApiRequestHub.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.SignalR;
+
+namespace Api.Presentation.WebApi.Hubs;
+
+public class ApiRequestHub : Hub<IApiRequestHubClient>
+{
+    public override async Task OnConnectedAsync()
+    {
+        string groupName = Context.GetHttpContext()!.Request.Headers["Ocp-Apim-Subscription-Key"]!;
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+
+        await base.OnConnectedAsync();
+    }
+}

--- a/src/Api.Presentation.WebApi/Hubs/IApiRequestHubClient.cs
+++ b/src/Api.Presentation.WebApi/Hubs/IApiRequestHubClient.cs
@@ -1,0 +1,8 @@
+﻿using Api.Core.Domain.Common;
+
+namespace Api.Presentation.WebApi.Hubs;
+
+public interface IApiRequestHubClient
+{
+    Task GetPendingRequests(GetPendingRequestsMessage getPendingRequestsMessage);
+}

--- a/src/Api.Presentation.WebApi/Program.cs
+++ b/src/Api.Presentation.WebApi/Program.cs
@@ -7,6 +7,7 @@ using Api.Core.Domain.Requests;
 using Api.Infrastructure;
 using Api.Infrastructure.Persistence;
 using Api.Presentation.WebApi.Authentication;
+using Api.Presentation.WebApi.Hubs;
 using ARSoftware.Contpaqi.Api.Common.Domain;
 using Microsoft.OpenApi.Models;
 
@@ -24,6 +25,8 @@ builder.Services.AddControllers(options =>
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
 builder.Services.AddApplicationServices().AddInfrastructureServices(builder.Configuration);
+
+builder.Services.AddSignalR();
 
 builder.Services.AddScoped<ApiKeyAuthFilter>();
 
@@ -81,6 +84,8 @@ app.UseSwaggerUI();
 app.UseHttpsRedirection();
 
 app.UseAuthorization();
+
+app.MapHub<ApiRequestHub>("/hubs/apiRequestHub");
 
 app.MapControllers();
 

--- a/src/Api.Sync.Core.Application/Common/Models/ApiSyncConfig.cs
+++ b/src/Api.Sync.Core.Application/Common/Models/ApiSyncConfig.cs
@@ -5,7 +5,6 @@ public sealed class ApiSyncConfig
     private readonly TimeOnly _timeStarted = TimeOnly.FromDateTime(DateTime.Now);
     public string SubscriptionKey { get; set; } = "00000000000000000000000000000000";
     public string BaseAddress { get; set; } = string.Empty;
-    public TimeOnly WaitTime { get; set; } = TimeOnly.MinValue;
     public TimeOnly ShutdownTime { get; set; } = new(20, 0, 0);
     public List<string> Empresas { get; set; } = new();
 

--- a/src/Api.Sync.Presentation.WorkerService/Api.Sync.Presentation.WorkerService.csproj
+++ b/src/Api.Sync.Presentation.WorkerService/Api.Sync.Presentation.WorkerService.csproj
@@ -15,6 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />

--- a/src/Api.Sync.Presentation.WorkerService/ApiRequestHubClientFactory.cs
+++ b/src/Api.Sync.Presentation.WorkerService/ApiRequestHubClientFactory.cs
@@ -1,0 +1,22 @@
+﻿using Api.Sync.Core.Application.Common.Models;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Api.Sync.Presentation.WorkerService;
+
+public sealed class ApiRequestHubClientFactory
+{
+    public static HubConnection BuildConnection(ApiSyncConfig apiSyncConfig)
+    {
+        HubConnection connection = new HubConnectionBuilder().WithUrl(new Uri($"{apiSyncConfig.BaseAddress}hubs/apiRequestHub"), options =>
+            {
+                options.Transports = HttpTransportType.WebSockets;
+                options.SkipNegotiation = true;
+                options.Headers.Add("Ocp-Apim-Subscription-Key", apiSyncConfig.SubscriptionKey);
+            })
+            .WithAutomaticReconnect()
+            .Build();
+
+        return connection;
+    }
+}

--- a/src/Api.Sync.Presentation.WorkerService/appsettings.Development.json
+++ b/src/Api.Sync.Presentation.WorkerService/appsettings.Development.json
@@ -24,8 +24,7 @@
     "Contpaqi": "Data Source=AR-SERVER\\COMPAC;User ID=sa;Password=Sdmramos1;Connect Timeout=30;Encrypt=False;"
   },
   "ApiSyncConfig": {
-    "BaseAddress": "https://localhost:7082/",
-    "WaitTime": "00:00:05"
+    "BaseAddress": "https://localhost:7082/"
   },
   "ContpaqiComercialConfig": {
     "Usuario": "SUPERVISOR",

--- a/src/Api.Sync.Presentation.WorkerService/appsettings.json
+++ b/src/Api.Sync.Presentation.WorkerService/appsettings.json
@@ -28,7 +28,6 @@
   "ApiSyncConfig": {
     "SubscriptionKey": "00000000000000000000000000000000",
     "BaseAddress": "https://contpaqiapim.azure-api.net/comercial/",
-    "WaitTime": "00:00:30",
     "ShutdownTime": "20:00:00",
     "Empresas": [ "URE180429TM6" ]
   },


### PR DESCRIPTION
En este PR se implementó SignalR en la API para poder notificar al sincronizador cuando hay solicitudes nuevas por procesar.

Cuando se crea una nueva solicitud en la API, la API notificara al sincronizador que debe consultar las solicitudes pendientes por procesar.  El sincronizador estará validando cada 1 segundo estas notificaciones, pero ya no haciendo un request a la API, sino una colección de notificaciones local. El procesamiento de las solicitudes debe sentirse ahora en tiempo real.

El motivo de este cambio es que, dependiendo de la configuración de los clientes, el sincronizador estaba consultando a la API si existían solicitudes pendientes y esto estaba consumiendo varios recursos y número de peticiones por licencia.
Si el cliente configuraba el sincronizador cada 1 segundo y lo dejaba abierto las 24 horas, esto se traducía a 86,400 solicitudes por dia o 2,592,000 al mes POR CLIENTE. Esto no era sustentable.

Este cambio mejorara los tiempos de ejecución y ahorrara recursos.