### PR TITLE
Corrige logica que termina el sincronizador

### DIFF
--- a/ARSoftware.Contpaqi.Comercial.Api.sln.DotSettings
+++ b/ARSoftware.Contpaqi.Comercial.Api.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForBuiltInTypes/@EntryValue">UseVarWhenEvident</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseVarWhenEvident</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseVarWhenEvident</s:String></wpf:ResourceDictionary>

--- a/src/Api.Sync.Core.Application/Common/Models/ApiSyncConfig.cs
+++ b/src/Api.Sync.Core.Application/Common/Models/ApiSyncConfig.cs
@@ -2,18 +2,24 @@
 
 public sealed class ApiSyncConfig
 {
-    private readonly TimeOnly _timeStarted = TimeOnly.FromDateTime(DateTime.Now);
+    private readonly DateTime _timeStarted = DateTime.Now;
+
+    public ApiSyncConfig()
+    {
+        ShutdownDateTime = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, ShutdownTime.Hour, ShutdownTime.Minute,
+            ShutdownTime.Second);
+
+        if (_timeStarted > ShutdownDateTime) ShutdownDateTime = ShutdownDateTime.AddDays(1);
+    }
+
     public string SubscriptionKey { get; set; } = "00000000000000000000000000000000";
     public string BaseAddress { get; set; } = string.Empty;
     public TimeOnly ShutdownTime { get; set; } = new(20, 0, 0);
     public List<string> Empresas { get; set; } = new();
+    private DateTime ShutdownDateTime { get; }
 
     public bool ShouldShutDown()
     {
-        bool startedAfterShutdownTime = _timeStarted > ShutdownTime;
-
-        bool isPastShutdownTime = TimeOnly.FromDateTime(DateTime.Now) >= ShutdownTime;
-
-        return !startedAfterShutdownTime && isPastShutdownTime;
+        return DateTime.Now >= ShutdownDateTime;
     }
 }

--- a/src/Api.Sync.Presentation.WorkerService/Worker.cs
+++ b/src/Api.Sync.Presentation.WorkerService/Worker.cs
@@ -65,6 +65,12 @@ public sealed class Worker : BackgroundService
 
             while (!stoppingToken.IsCancellationRequested)
             {
+                if (_apiSyncConfig.ShouldShutDown())
+                {
+                    _logger.LogInformation("La aplicación debe apagarse.");
+                    break;
+                }
+
                 if (_pendingRequestQueue.IsEmpty)
                 {
                     _logger.LogDebug("Esperando solicitudes nuevas.");
@@ -98,12 +104,6 @@ public sealed class Worker : BackgroundService
 
                         await _mediator.Send(new ProcessApiRequestCommand(apiRequest), stoppingToken);
                     }
-                }
-
-                if (_apiSyncConfig.ShouldShutDown())
-                {
-                    _logger.LogInformation("La aplicación debe apagarse.");
-                    break;
                 }
             }
         }


### PR DESCRIPTION
En este PR se corrige la lógica que validaba el tiempo de apagado del sincronizador ya que solo se validaba después de procesar una solicitud. Si no se procesaba una solicitud se quedaba en el loop y nunca se apagaba el cual podia causar errores.