### PR TITLE
Corrige error cuando al crear una respuesta invalida se tragaba el error

### DIFF
--- a/src/Api.Presentation.WebApi/Api.Presentation.WebApi.csproj
+++ b/src/Api.Presentation.WebApi/Api.Presentation.WebApi.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<Version>2.5.0</Version>
+		<Version>2.5.1</Version>
 		<Authors>AR Software</Authors>
 		<Company>AR Software</Company>
 		<Description>API para generar solicitudes para ser procesadas en CONTPAQi Comercial.</Description>

--- a/src/Api.Presentation.WebApi/Controllers/ResponsesController.cs
+++ b/src/Api.Presentation.WebApi/Controllers/ResponsesController.cs
@@ -43,8 +43,7 @@ public class ResponsesController : ControllerBase
     {
         ApiRequest? request = await _mediator.Send(new GetApiRequestByIdQuery(id, ApimSubscriptionKey));
 
-        if (request?.Response is null)
-            return NotFound();
+        if (request?.Response is null) return NotFound();
 
         return Ok(request.Response);
     }
@@ -52,14 +51,7 @@ public class ResponsesController : ControllerBase
     [HttpPost]
     public async Task<ActionResult> Post([FromRoute] Guid id, ApiResponse apiResponse)
     {
-        try
-        {
-            await _mediator.Send(new CreateApiResponseCommand(apiResponse, ApimSubscriptionKey, id));
-        }
-        catch (Exception e)
-        {
-            BadRequest(e.Message);
-        }
+        await _mediator.Send(new CreateApiResponseCommand(apiResponse, ApimSubscriptionKey, id));
 
         return Ok();
     }
@@ -81,8 +73,7 @@ public class ResponsesController : ControllerBase
 
         Type? type = responseType.Assembly.GetType(responseFullName);
 
-        if (type is null)
-            throw new InvalidOperationException($"Couldn't find type for response with name {responseFullName}.");
+        if (type is null) throw new InvalidOperationException($"Couldn't find type for response with name {responseFullName}.");
 
         if (Activator.CreateInstance(type) is not ContpaqiResponse instance)
             throw new InvalidOperationException($"Couldn't create instance for type {type}.");

--- a/src/Api.Presentation.WebApi/Program.cs
+++ b/src/Api.Presentation.WebApi/Program.cs
@@ -24,6 +24,9 @@ builder.Services.AddControllers(options =>
         options.JsonSerializerOptions.TypeInfoResolver = new PolymorphicTypeResolver();
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
+
+builder.Services.AddProblemDetails();
+
 builder.Services.AddApplicationServices().AddInfrastructureServices(builder.Configuration);
 
 builder.Services.AddSignalR();


### PR DESCRIPTION
Este PR corrige un error en donde al crear un `ApiResponse` invalido la API se tragaba el error y retornaba un `status 200` el cual era incorrecto.

Esto ocasionaba que las `ApiRequest` se quedaran con el estatus `Pending` dejando al usuario sin contexto de que un error había sucedido.

Closes #48 