### PR TITLE
feat: agrega solicitud para eliminar unidades de medida

### DIFF
--- a/samples/Api.Sdk.ConsoleApp/JsonFactories/UnidadesMedidaFactory.cs
+++ b/samples/Api.Sdk.ConsoleApp/JsonFactories/UnidadesMedidaFactory.cs
@@ -40,6 +40,17 @@ public static class UnidadesMedidaFactory
         return new BuscarUnidadesMedidaResponse(new BuscarUnidadesMedidaResponseModel(new List<UnidadMedida> { GetModeloPrueba() }));
     }
 
+    private static EliminarUnidadMedidaRequest GetEliminarUnidadMedidaRequest()
+    {
+        return new EliminarUnidadMedidaRequest(new EliminarUnidadMedidaRequestModel { NombreUnidad = "PRUEBA" },
+            new EliminarUnidadMedidaRequestOptions());
+    }
+
+    private static EliminarUnidadMedidaResponse GetEliminarUnidadMedidaResponse()
+    {
+        return new EliminarUnidadMedidaResponse(new EliminarUnidadMedidaResponseModel());
+    }
+
     public static UnidadMedida GetModeloPrueba()
     {
         return new UnidadMedida { Nombre = "PRUEBA", Abreviatura = "PZ", ClaveSat = "H87" };
@@ -67,5 +78,11 @@ public static class UnidadesMedidaFactory
             JsonSerializer.Serialize<ContpaqiRequest>(GetBuscarUnidadesMedidaRequest(), options));
         File.WriteAllText(Path.Combine(directory, $"{nameof(BuscarUnidadesMedidaResponse)}.json"),
             JsonSerializer.Serialize<ContpaqiResponse>(GetBuscarUnidadesMedidaResponse(), options));
+
+        File.WriteAllText(Path.Combine(directory, $"{nameof(EliminarUnidadMedidaRequest)}.json"),
+            JsonSerializer.Serialize<ContpaqiRequest>(GetEliminarUnidadMedidaRequest(), options));
+
+        File.WriteAllText(Path.Combine(directory, $"{nameof(EliminarUnidadMedidaResponse)}.json"),
+            JsonSerializer.Serialize<ContpaqiResponse>(GetEliminarUnidadMedidaResponse(), options));
     }
 }

--- a/src/Api.Core.Domain/Common/PolymorphicTypeResolver.cs
+++ b/src/Api.Core.Domain/Common/PolymorphicTypeResolver.cs
@@ -55,6 +55,7 @@ public sealed class PolymorphicTypeResolver : DefaultJsonTypeInfoResolver
                     new JsonDerivedType(typeof(EliminarClienteRequest), nameof(EliminarClienteRequest)),
                     new JsonDerivedType(typeof(EliminarDocumentoRequest), nameof(EliminarDocumentoRequest)),
                     new JsonDerivedType(typeof(EliminarProductoRequest), nameof(EliminarProductoRequest)),
+                    new JsonDerivedType(typeof(EliminarUnidadMedidaRequest), nameof(EliminarUnidadMedidaRequest)),
                     new JsonDerivedType(typeof(GenerarDocumentoDigitalRequest), nameof(GenerarDocumentoDigitalRequest)),
                     new JsonDerivedType(typeof(SaldarDocumentoRequest), nameof(SaldarDocumentoRequest)),
                     new JsonDerivedType(typeof(TimbrarDocumentoRequest), nameof(TimbrarDocumentoRequest))
@@ -103,6 +104,7 @@ public sealed class PolymorphicTypeResolver : DefaultJsonTypeInfoResolver
                     new JsonDerivedType(typeof(EliminarClienteResponse), nameof(EliminarClienteResponse)),
                     new JsonDerivedType(typeof(EliminarDocumentoResponse), nameof(EliminarDocumentoResponse)),
                     new JsonDerivedType(typeof(EliminarProductoResponse), nameof(EliminarProductoResponse)),
+                    new JsonDerivedType(typeof(EliminarUnidadMedidaResponse), nameof(EliminarUnidadMedidaResponse)),
                     new JsonDerivedType(typeof(EmptyContpaqiResponse), nameof(EmptyContpaqiResponse)),
                     new JsonDerivedType(typeof(ErrorContpaqiResponse), nameof(ErrorContpaqiResponse)),
                     new JsonDerivedType(typeof(GenerarDocumentoDigitalResponse), nameof(GenerarDocumentoDigitalResponse)),

--- a/src/Api.Core.Domain/Requests/UnidadesMedida/EliminarUnidadMedida.cs
+++ b/src/Api.Core.Domain/Requests/UnidadesMedida/EliminarUnidadMedida.cs
@@ -1,0 +1,50 @@
+﻿using ARSoftware.Contpaqi.Api.Common.Domain;
+
+namespace Api.Core.Domain.Requests;
+
+/// <summary>
+///     Solicitud para eliminar una unidad de medida.
+/// </summary>
+public sealed class EliminarUnidadMedidaRequest : ContpaqiRequest<EliminarUnidadMedidaRequestModel, EliminarUnidadMedidaRequestOptions,
+    EliminarUnidadMedidaResponse>
+{
+    public EliminarUnidadMedidaRequest(EliminarUnidadMedidaRequestModel model, EliminarUnidadMedidaRequestOptions options) : base(model,
+        options)
+    {
+    }
+}
+
+/// <summary>
+///     Modelo de la solicitud EliminarUnidadMedidaRequest.
+/// </summary>
+public sealed class EliminarUnidadMedidaRequestModel
+{
+    /// <summary>
+    ///     Nombre de la unidad de medida.
+    /// </summary>
+    public string NombreUnidad { get; set; }
+}
+
+/// <summary>
+///     Opciones de la solicitud EliminarUnidadMedidaRequest.
+/// </summary>
+public sealed class EliminarUnidadMedidaRequestOptions
+{
+}
+
+/// <summary>
+///     Respuesta a la solicitud EliminarUnidadMedidaRequest.
+/// </summary>
+public sealed class EliminarUnidadMedidaResponse : ContpaqiResponse<EliminarUnidadMedidaResponseModel>
+{
+    public EliminarUnidadMedidaResponse(EliminarUnidadMedidaResponseModel model) : base(model)
+    {
+    }
+}
+
+/// <summary>
+///     Modelo de la respuesta EliminarUnidadMedidaResponse.
+/// </summary>
+public sealed class EliminarUnidadMedidaResponseModel
+{
+}

--- a/src/Api.Sync.Core.Application/Requests/UnidadesMedida/EliminarUnidadMedida/EliminarUnidadMedidaRequestHandler.cs
+++ b/src/Api.Sync.Core.Application/Requests/UnidadesMedida/EliminarUnidadMedida/EliminarUnidadMedidaRequestHandler.cs
@@ -1,0 +1,22 @@
+﻿using Api.Core.Domain.Requests;
+using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
+using MediatR;
+
+namespace Api.Sync.Core.Application.Requests.UnidadesMedida.EliminarUnidadMedida;
+
+public sealed class EliminarUnidadMedidaRequestHandler : IRequestHandler<EliminarUnidadMedidaRequest, EliminarUnidadMedidaResponse>
+{
+    private readonly IUnidadMedidaService _unidadMedidaService;
+
+    public EliminarUnidadMedidaRequestHandler(IUnidadMedidaService unidadMedidaService)
+    {
+        _unidadMedidaService = unidadMedidaService;
+    }
+
+    public Task<EliminarUnidadMedidaResponse> Handle(EliminarUnidadMedidaRequest request, CancellationToken cancellationToken)
+    {
+        _unidadMedidaService.Eliminar(request.Model.NombreUnidad);
+
+        return Task.FromResult(new EliminarUnidadMedidaResponse(new EliminarUnidadMedidaResponseModel()));
+    }
+}


### PR DESCRIPTION
Este PR agrega una nueva solicitud que te permite eliminar unidades de medida.

```json
{
  "$type": "BuscarUnidadesMedidaRequest",
  "model": {},
  "options": {
    "cargarDatosExtra": false
  }
}
```