### PR TITLE
agrega modelo para crear un producto con unidad y control existencia

### DIFF
--- a/samples/Api.Sdk.ConsoleApp/JsonFactories/ProductoFactory.cs
+++ b/samples/Api.Sdk.ConsoleApp/JsonFactories/ProductoFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Api.Core.Domain.Requests;
 using ARSoftware.Contpaqi.Api.Common.Domain;
+using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Enums;
 using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Models;
 using ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
 
@@ -65,6 +66,31 @@ public static class ProductoFactory
         };
     }
 
+    private static Producto GetModeloConUnidadMedida()
+    {
+        return new Producto
+        {
+            Codigo = "PRUEBAUNI",
+            Nombre = "PRODUCTO CON UNIDAD",
+            ControlExistencias = ControlExistencias.Unidades,
+            UnidadMedida = new UnidadMedida { Nombre = "PIEZA" },
+            ClaveSat = "43231500",
+            DatosExtra = GetDatosExtraPrueba()
+        };
+    }
+
+    private static Producto GetModeloConMultipleControlExistencias()
+    {
+        return new Producto
+        {
+            Codigo = "PRUEBAEXIS",
+            Nombre = "PRODUCTO CON MULTPLES EXISTENCIAS",
+            ControlExistencias = ControlExistencias.Series | ControlExistencias.Pedimentos,
+            ClaveSat = "43231500",
+            DatosExtra = GetDatosExtraPrueba()
+        };
+    }
+
     private static Dictionary<string, string> GetDatosExtraPrueba()
     {
         return new Dictionary<string, string>
@@ -83,6 +109,10 @@ public static class ProductoFactory
         JsonSerializerOptions options = FactoryExtensions.GetJsonSerializerOptions();
 
         File.WriteAllText(Path.Combine(directory, $"{nameof(Producto)}.json"), JsonSerializer.Serialize(GetModeloPrueba(), options));
+        File.WriteAllText(Path.Combine(directory, $"{nameof(Producto)}ConUnidadMedida.json"),
+            JsonSerializer.Serialize(GetModeloConUnidadMedida(), options));
+        File.WriteAllText(Path.Combine(directory, $"{nameof(Producto)}ConMultipleControlExistencias.json"),
+            JsonSerializer.Serialize(GetModeloConMultipleControlExistencias(), options));
 
         File.WriteAllText(Path.Combine(directory, $"{nameof(CrearProductoRequest)}.json"),
             JsonSerializer.Serialize<ContpaqiRequest>(GetCrearProductoRequest(), options));


### PR DESCRIPTION
Agrega modelo en json para crear un producto con unidad de medida y un producto con multiple control de existencias.

Para crear un producto con unidad de medida:

```json
{
  "id": 0,
  "codigo": "PRUEBAUNI",
  "nombre": "PRODUCTO CON UNIDAD",
  "tipo": "Producto",
  "controlExistencias": "Unidades",
  "unidadMedida": {
    "nombre": "PIEZA"
  },
  "claveSat": "43231500",
  "datosExtra": {
    "CCLAVESAT": "43231500",
    "CTEXTOEXTRA1": "Texto extra 1",
    "CTEXTOEXTRA2": "Texto extra 2",
    "CTEXTOEXTRA3": "Texto extra 3"
  }
}
```

Para crear un producto con mutiple control existencias:

```json
{
  "id": 0,
  "codigo": "PRUEBAEXIS",
  "nombre": "PRODUCTO CON MULTPLES EXISTENCIAS",
  "tipo": "Producto",
  "controlExistencias": "Series, Pedimentos",
  "claveSat": "43231500",
  "datosExtra": {
    "CCLAVESAT": "43231500",
    "CTEXTOEXTRA1": "Texto extra 1",
    "CTEXTOEXTRA2": "Texto extra 2",
    "CTEXTOEXTRA3": "Texto extra 3"
  }
}
```